### PR TITLE
fix: added support for max cluster radius functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- maxClusterRadius now accepts also functions as input value
+
 ## 0.6.0 - 2024-02-13
 ### Added
 - added [iconCreateFunction](https://github.com/Leaflet/Leaflet.markercluster/?tab=readme-ov-file#customising-the-clustered-markers) prop.

--- a/src/functions/markerClusterGroup.ts
+++ b/src/functions/markerClusterGroup.ts
@@ -49,7 +49,7 @@ export const markerClusterGroupProps = {
    * current map zoom and returns the maximum cluster radius in pixels.
    **/
   maxClusterRadius: {
-    type: Number,
+    type: [Number, Function],
     default: 80
   },
   /**

--- a/src/functions/markerClusterGroup.ts
+++ b/src/functions/markerClusterGroup.ts
@@ -211,7 +211,7 @@ export const markerClusterGroupProps = {
     type: Function,
     default: null
   }
-} as const
+}
 
 export const setupMarkerClusterGroup = (
   props: ExtractPropTypes<typeof markerClusterGroupProps>,


### PR DESCRIPTION
Fixes: https://github.com/veitbjarsch/vue-leaflet-markercluster/issues/22